### PR TITLE
add pause menu

### DIFF
--- a/src/level/crystal.rs
+++ b/src/level/crystal.rs
@@ -25,7 +25,8 @@ impl Plugin for CrystalPlugin {
                     .after(update_activatables)
                     .in_set(LevelSystems::Simulation),
             )
-            .add_systems(OnEnter(GameState::Playing), reset_crystals);
+            .add_systems(OnExit(GameState::Switching), reset_crystals)
+            .add_systems(OnExit(GameState::Respawning), reset_crystals);
     }
 }
 

--- a/src/light/mod.rs
+++ b/src/light/mod.rs
@@ -37,7 +37,11 @@ impl Plugin for LightManagementPlugin {
                     .in_set(LevelSystems::Simulation),
             )
             .add_systems(
-                OnEnter(GameState::Playing),
+                OnExit(GameState::Switching),
+                (cleanup_light_sources, reset_light_sensors),
+            )
+            .add_systems(
+                OnExit(GameState::Respawning),
                 (cleanup_light_sources, reset_light_sensors),
             )
             .add_systems(

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use config::ConfigPlugin;
 use input::{init_cursor_world_coords, update_cursor_world_coords};
 use level::LevelManagementPlugin;
 use light::LightManagementPlugin;
+use pause::PausePlugin;
 use player::PlayerManagementPlugin;
 use shared::GameState;
 
@@ -17,6 +18,7 @@ mod config;
 mod input;
 mod level;
 mod light;
+mod pause;
 mod player;
 mod shared;
 
@@ -51,6 +53,7 @@ fn main() {
         .add_plugins(PlayerManagementPlugin)
         .add_plugins(LevelManagementPlugin)
         .add_plugins(LightManagementPlugin)
+        .add_plugins(PausePlugin)
         .add_plugins(CameraPlugin)
         .insert_state(GameState::Playing)
         .add_systems(Startup, init_cursor_world_coords)

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -1,0 +1,53 @@
+use bevy::{input::common_conditions::input_just_pressed, prelude::*};
+
+use crate::shared::GameState;
+
+pub struct PausePlugin;
+
+impl Plugin for PausePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(OnEnter(GameState::Paused), spawn_pause)
+            .add_systems(OnExit(GameState::Paused), despawn_pause)
+            .add_systems(
+                Update,
+                toggle_pause.run_if(input_just_pressed(KeyCode::Escape)),
+            );
+    }
+}
+
+#[derive(Component)]
+pub struct PauseMarker;
+
+fn spawn_pause(mut commands: Commands) {
+    commands
+        .spawn((
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                ..default()
+            },
+            BackgroundColor(Color::linear_rgba(0., 0., 0., 0.0)),
+            PauseMarker,
+        ))
+        .with_child((
+            Text::new("Paused"),
+            TextColor(Color::linear_rgb(1.0, 1.0, 1.0)),
+        ));
+}
+
+fn despawn_pause(mut commands: Commands, query: Query<Entity, With<PauseMarker>>) {
+    let Ok(entity) = query.get_single() else {
+        return;
+    };
+    commands.entity(entity).despawn_recursive();
+}
+
+fn toggle_pause(state: Res<State<GameState>>, mut next_state: ResMut<NextState<GameState>>) {
+    next_state.set(match state.get() {
+        GameState::Paused => GameState::Playing,
+        GameState::Playing => GameState::Paused,
+        x => x.clone(),
+    })
+}

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -50,7 +50,8 @@ impl Plugin for PlayerManagementPlugin {
                 .in_set(LevelSystems::Simulation)
                 .after(update_cursor_world_coords),
         )
-        .add_systems(OnEnter(GameState::Playing), reset_player_on_level_switch)
+        .add_systems(OnExit(GameState::Switching), reset_player_on_level_switch)
+        .add_systems(OnExit(GameState::Respawning), reset_player_on_level_switch)
         .add_systems(OnEnter(GameState::Respawning), reset_player_position)
         .add_systems(
             Update,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -19,4 +19,5 @@ pub enum GameState {
     Playing,
     Respawning,
     Switching,
+    Paused,
 }


### PR DESCRIPTION
Addresses issue #47 

Adding the new `Paused` gamestate broke the resetting logic (as was predicted in the issue), which I fixed by turning all `OnEnter(GameState::Playing)` into two schedules, `OnExit(GameState::Switching)` and `OnExit(GameState::Respawning)`. Maybe events could be better for this? 